### PR TITLE
Suppress output of OCR'd text to the stdout stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ async function getScreenText(vmName) {
   let output = "";
   await exec.exec("pytesseract  " + png, [], {
     listeners: {
+      silent: true,
       stdout: (s) => {
         output += s;
       }


### PR DESCRIPTION
Fixes #8 

It looks like `exec` has a `silent` option that _should_ continue to execute our listener but not inherit the stream of the parent process.