### PR TITLE
Update to FreeBSD-13.0-RELEASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Test in FreeBSD
       id: test
-      uses: vmactions/freebsd-vm@v0.1.2
+      uses: vmactions/freebsd-vm@v0.1.4
       with:
         envs: 'MYTOKEN MYTOKEN2'
         usesh: true
@@ -72,13 +72,13 @@ The code is shared from the host to the FreeBSD VM via `rsync`, you can choose t
     - uses: actions/checkout@v2
     - name: Test in FreeBSD
       id: test
-      uses: vmactions/freebsd-vm@v0.1.2
+      uses: vmactions/freebsd-vm@v0.1.4
       with:
         envs: 'MYTOKEN MYTOKEN2'
         usesh: true
         sync: sshfs
         prepare: pkg install -y curl
-      
+
 
 
 ...
@@ -94,7 +94,7 @@ You can add NAT port between the host and the VM.
     - uses: actions/checkout@v2
     - name: Test in FreeBSD
       id: test
-      uses: vmactions/freebsd-vm@v0.1.2
+      uses: vmactions/freebsd-vm@v0.1.4
       with:
         envs: 'MYTOKEN MYTOKEN2'
         usesh: true
@@ -114,7 +114,7 @@ The default memory of the VM is 1024MB, you can use `mem` option to set the memo
     - uses: actions/checkout@v2
     - name: Test in FreeBSD
       id: test
-      uses: vmactions/freebsd-vm@v0.1.2
+      uses: vmactions/freebsd-vm@v0.1.4
       with:
         envs: 'MYTOKEN MYTOKEN2'
         usesh: true
@@ -125,7 +125,7 @@ The default memory of the VM is 1024MB, you can use `mem` option to set the memo
 
 # Under the hood
 
-GitHub only supports Ubuntu, Windows and MacOS out of the box. 
+GitHub only supports Ubuntu, Windows and MacOS out of the box.
 
 However, the MacOS support virtualization. It has VirtualBox installed.
 

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ async function setup(nat, mem) {
 
     let workingDir = __dirname;
 
-    let url = "https://github.com/vmactions/freebsd-builder/releases/download/v0.0.8/freebsd-13.0.7z";
+    let url = "https://github.com/vmactions/freebsd-builder/releases/download/v0.0.9/freebsd-13.0.7z";
 
     core.info("Downloading image: " + url);
     let img = await tc.downloadTool(url);

--- a/index.js
+++ b/index.js
@@ -87,13 +87,13 @@ async function setup(nat, mem) {
 
     let workingDir = __dirname;
 
-    let url = "https://github.com/vmactions/freebsd-builder/releases/download/v0.0.8/freebsd-12.2.7z";
+    let url = "https://github.com/vmactions/freebsd-builder/releases/download/v0.0.8/freebsd-13.0.7z";
 
     core.info("Downloading image: " + url);
     let img = await tc.downloadTool(url);
     core.info("Downloaded file: " + img);
 
-    let s7z = workingDir + "/freebsd-12.2.7z";
+    let s7z = workingDir + "/freebsd-13.0.7z";
     await io.mv(img, s7z);
     await exec.exec("7z e " + s7z + "  -o" + workingDir);
 
@@ -106,7 +106,7 @@ async function setup(nat, mem) {
     await exec.exec("chmod 700 " + sshHome);
 
 
-    let ova = "freebsd-12.2.ova";
+    let ova = "freebsd-13.0.ova";
     await vboxmanage("", "import", path.join(workingDir, ova));
 
 


### PR DESCRIPTION
FreeBSD-13.0-RELEASE released on 13.04.2021. It's a great release. Let's switch on it.
https://www.freebsd.org/releases/13.0R/announce/