### PR TITLE
fix: fusefs use under FreeBSD 13

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ async function setup(nat, mem) {
 
     let sync = core.getInput("sync");
     if (sync == "sshfs") {
-      let cmd2 = "pkg  install  -y fusefs-sshfs && kldload  fuse.ko && sshfs -o allow_other,default_permissions runner@10.0.2.2:work /Users/runner/work";
+      let cmd2 = "pkg  install  -y fusefs-sshfs && kldload  fusefs && sshfs -o allow_other,default_permissions runner@10.0.2.2:work /Users/runner/work";
       await execSSH(cmd2, "Setup sshfs");
     } else {
       let cmd2 = "pkg  install  -y rsync";


### PR DESCRIPTION
`kldload fuse.ko` now throws an error, as per the install message, it seems `kldload fusefs` should be used instead.

Using fuse with the latest version throws this error:
```
exec ssh: pkg  install  -y fusefs-sshfs && kldload  fuse.ko && sshfs -o allow_other,default_permissions runner@10.0.2.2:work /Users/runner/work
[command]/usr/bin/ssh -t freebsd
[...]
=====
Message from fusefs-libs3-3.10.2_1:

--
Install the FUSE kernel module (kldload fusefs) to use this port.
[...]
For further options see ``sshfs -h''.
kldload: can't load fuse.ko: No such file or directory
```