### PR TITLE
hooks/waitForBooting.sh: retry upon OCR failure

### DIFF
--- a/hooks/waitForBooting.sh
+++ b/hooks/waitForBooting.sh
@@ -1,11 +1,16 @@
-
-
+#!/bin/sh
 
 echo "====> Wait for Boot Multi user"
-if bash vbox.sh waitForText $VM_OS_NAME "Boot Multi user" 10 ; then
-  echo "====> OK, enter"
-  bash vbox.sh enter
-fi
+try_counter=0
+while ! bash vbox.sh waitForText "$VM_OS_NAME" "Boot Multi user" 10 ; do
+  if [ "$try_counter" -ge 10 ] ; then
+    echo "====> Too many tries... exiting."
+    exit 1
+  fi
+  echo "====> Timed out, trying again..."
+  try_counter=$((1+try_counter))
+  sleep 1
+done
 
-
-
+echo "====> OK, enter"
+bash vbox.sh enter


### PR DESCRIPTION
In case it takes more than 10 seconds to boot (which is very possible), this will cause it to retry up to a maximum of 10 times.
