### PR TITLE
Bump InsonusK/get-latest-release to v1.1.0

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: '2'
       - name: Get latest release
         id: get-latest-release
-        uses: InsonusK/get-latest-release@v1.0.1
+        uses: InsonusK/get-latest-release@v1.1.0
         with:
           myToken: ${{ github.token }}
           view_top: 1

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Get latest release
         id: get-latest-release
-        uses: InsonusK/get-latest-release@v1.0.1
+        uses: InsonusK/get-latest-release@v1.1.0
         with:
           myToken: ${{ github.token }}
           view_top: 1

--- a/.github/workflows/syncbase.yml
+++ b/.github/workflows/syncbase.yml
@@ -21,7 +21,7 @@ jobs:
           token: ${{ secrets.VM_TOKEN }}
       - name: Get latest release
         id: get-latest-release
-        uses: InsonusK/get-latest-release@v1.0.1
+        uses: InsonusK/get-latest-release@v1.1.0
         with:
           myToken: ${{ github.token }}
           view_top: 1


### PR DESCRIPTION
Fixes deprecation warnings
`The following actions uses node12 which is deprecated and will be forced to run on node16: InsonusK/get-latest-release@v1.0.1`