### PR TITLE
fix(action): remove required property of `run` input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: false
   run:
     description: 'The CI command to run'
-    required: true
+    required: false
   release:
     description: 'The release version of FreeBSD vm'
     required: false


### PR DESCRIPTION
This PR changes `run` from required `true` to `false` as it is not actually required. With this set to required it causes syntax highlighting errors in the IDE as well as causing major confusion with co-pilot.

