### PR TITLE
DRAFT: Refactor onStarted.sh style and enhance with diagnostic info

### DIFF
--- a/hooks/onStarted.sh
+++ b/hooks/onStarted.sh
@@ -1,15 +1,22 @@
 #!/usr/bin/env sh
-
 #run in the vm as soon as the vm is started, before run the "prepare"
 
+# try to print some diognostic info (but don't fail here): OS, VM specs, VM date, VM user
+# FreeBSD version
+freebsd-version || true
+# VM specs
+uname -r -p -m -s 2>/dev/null || uname 2>/dev/null || true
+# VM's date
+date -u || true
+# User login diognostics
+printf '%s\n' "Running as user:" || true
+whoami 2>/dev/null || who -m 2>/dev/null || true
+printf '%s\n' "Home: ${HOME:-.}" || true
 
-freebsd-version
-
-date -u
-
-if ! kldload  fusefs ; then
+# loade fuse filesystem kernel module (if able)
+if ! kldload  fusefs 2>/dev/null; then
   #ok, kldload: can't load fusefs: module already loaded or in kernel 
-  echo ""
+  printf "\n" # retrun fast
 fi
 
 #switch to latest source
@@ -17,10 +24,11 @@ fi
 if grep "quarterly" /etc/pkg/FreeBSD.conf; then
   sed -i '' 's#/quarterly#/latest#g' /etc/pkg/FreeBSD.conf
   rm -rf /var/db/pkg/repos/*
-  cat /etc/pkg/FreeBSD.conf
+  cat /etc/pkg/FreeBSD.conf ;
 fi
 
+# add additional hooks here
 
 
 
-
+# TODO: should exit here to cleanup


### PR DESCRIPTION
Added diagnostic information printing for OS, VM specs, date, and user login. Also cleaned up script style.

Rationale and details of changes:

* added additional diagnostics from `uname`
* added additional diagnostics about user (prep for vmactions/freebsd-vm#59)
* added comments (for readability)
* removed some extra whitespace (trivial maintainability)
* use faster `printf` over `echo` (marginal performance gain from _portable_ builtin `printf` versus possible find and load of `/bin/echo`)